### PR TITLE
支持非json格式的data

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ function request(options, callback) {
     if (opts.method === 'GET') {
       opts.url += '?' + querystring.stringify(opts.data);
     } else {
-      opts.data = JSON.stringify(opts.data);
+      if (!util.isString(opts.data))
+        opts.data = JSON.stringify(opts.data);
       opts.headers['Content-Length'] = new Buffer(opts.data).length;
     }
   }


### PR DESCRIPTION
如果opts.data是字符串，就直接当作data进行发送，不要再进行JSON.stringfy的转换，这样可以支持一些非json格式的接口