### PR TITLE
add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+test
+
+Gruntfile.js


### PR DESCRIPTION
Hi 👋

I’ve been doing a little research for a conference talk on how npm package size relates to their content, and your package was one in the several ones that were flagged by my scripts.  It has an outstanding weekly download count on npm and relatively large content that is not related directly to the package functionality.

I've added some files and folders to an .npmignore file, so they won't get packaged next time you release it on npm.

Thanks, and have a great day!
